### PR TITLE
Fixed bug where remainingMb Is Null not regognised for unlimited plans

### DIFF
--- a/ABBUsage/@Resources/Scripts/ABB-Usage.vbs
+++ b/ABBUsage/@Resources/Scripts/ABB-Usage.vbs
@@ -167,7 +167,7 @@ Set objUsageJSON = parse_json(UsageJSON)
 DownVal = objUsageJSON.downloadedMb * 1000 * 1000
 UpVal = objUsageJSON.uploadedMb * 1000 * 1000
 
-If objUsageJSON.remainingMb = "" Then
+If objUsageJSON.remainingMb = "" Or objUsageJSON.remainingMb Is Null Then
   ' Unlimited plan (skin uses allowance1_mb >= 100,000,000 as trigger)
   AllowanceMB = 100000000
   LeftVal = 0


### PR DESCRIPTION
Yep, you were right.  The string looked like it was empty but it was in fact a NULL.

Code fixed and tested successfully with your json data.